### PR TITLE
docs: Carify jandex version used in the README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@
 :project-name:    jandex-gradle-plugin
 :project-group:   org.kordamp.gradle
 :project-version: 1.1.0
-:jandex-version:  3.0.0
+:jandex-version:  3.0.5
 :plugin-id:       {project-group}.jandex
 
 image:https://img.shields.io/github/actions/workflow/status/{project-owner}/{project-name}/early-access.yml?branch=master&logo=github&label=Build["Build Status", link="https://github.com/{project-owner}/{project-name}/actions"]
@@ -77,12 +77,12 @@ $ gradle jandex
 === Jandex Version
 
 This plugin relies on Jandex {jandex-version} to perform its job, however you may configure a different version if needed.
-Simply add the maven coordinates to the `jandex` extension as shown next
+Simply add the desired version (for the maven coordinates `io.smallrye:jandex:<version>`) to the `jandex` extension as shown next
 
 [source,groovy]
 ----
 jandex {
-    version = '2.2.1.Final'
+    version = '3.0.0'
 }
 ----
 


### PR DESCRIPTION
When nothing is specified, this is used:
https://github.com/kordamp/jandex-gradle-plugin/blob/8b9f8795c02034dbf73af9d18b77e60afa76cb21/gradle.properties#L23

And was changed with commit 960c09be5f7aacdfe2e16932ea2c9ac933365660 from `3.0.0` to `3.0.5`

Also the example of using `2.2.1.Final` will not work since this is not available for the groupId `io.smallrye` which is used since commit 982e9e65b3cce68933b02315cf37407caa9ff5a5